### PR TITLE
Cambonos 25.11

### DIFF
--- a/cambonos-fs/etc/X11/xorg.conf.d/30-touchpad.conf
+++ b/cambonos-fs/etc/X11/xorg.conf.d/30-touchpad.conf
@@ -1,0 +1,13 @@
+Section "InputClass"
+    Identifier "touchpad"
+    MatchIsTouchpad "on"
+    Driver "libinput"
+
+    Option "Tapping" "on"
+    Option "NaturalScrolling" "true"
+    Option "DisableWhileTyping" "true"
+    Option "ScrollMethod" "twofinger"
+    Option "ClickMethod" "clickfinger"
+    Option "AccelSpeed" "0.15"
+    Option "HorizontalScrolling" "true"
+EndSection

--- a/cambonos-fs/etc/pacman.conf
+++ b/cambonos-fs/etc/pacman.conf
@@ -80,8 +80,8 @@ Include = /etc/pacman.d/mirrorlist
 #[community-testing]
 #Include = /etc/pacman.d/mirrorlist
 
-[community]
-Include = /etc/pacman.d/mirrorlist
+#[community]
+#Include = /etc/pacman.d/mirrorlist
 
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.

--- a/cambonos-fs/etc/sudoers
+++ b/cambonos-fs/etc/sudoers
@@ -82,10 +82,11 @@ root ALL=(ALL) ALL
 %wheel ALL=(ALL) ALL
 
 ## Same thing without a password
-updates ALL=(ALL) NOPASSWD: /usr/bin/rm /var/lib/pacman/db.lck
+updates ALL=(ALL) NOPASSWD: /usr/bin/systemd-inhibit
+updates ALL=(ALL) NOPASSWD: /usr/bin/rm -f /var/lib/pacman/db.lck
 updates ALL=(ALL) NOPASSWD: /usr/bin/pacman
 updates ALL=(ALL) NOPASSWD: /usr/bin/makepkg -sri --noconfirm -E
-updates ALL=(ALL) NOPASSWD: /usr/bin/grub-mkconfig
+updates ALL=(ALL) NOPASSWD: /usr/bin/grub-mkconfig -o /boot/grub/grub.cfg
 
 ## Uncomment to allow members of group sudo to execute any command
 # %sudo	ALL=(ALL) ALL

--- a/cambonos-fs/etc/systemd/system/cambonos-upgrade.service
+++ b/cambonos-fs/etc/systemd/system/cambonos-upgrade.service
@@ -1,11 +1,18 @@
 [Unit]
 Description=CambonOS Upgrade Service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 User=updates
-RemainAfterExit=yes
+Group=updates
 ExecStart=/usr/bin/cambonos-upgrade
+RemainAfterExit=no
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=cambonos-upgrade
+
+# Durante apagado espera antes de forzar kill
+TimeoutStopSec=60
+KillMode=control-group

--- a/cambonos-fs/etc/systemd/system/cambonos-upgrade.timer
+++ b/cambonos-fs/etc/systemd/system/cambonos-upgrade.timer
@@ -2,7 +2,7 @@
 Description=CambonOS Upgrade Timer
 
 [Timer]
-OnCalendar=*-*-* 03:00:00
+OnCalendar=daily
 Persistent=true
 
 [Install]

--- a/cambonos-fs/usr/bin/cambonos-upgrade
+++ b/cambonos-fs/usr/bin/cambonos-upgrade
@@ -1,35 +1,70 @@
 #!/bin/bash
 
+# -------------------------------
+# Configuración de colores
+# -------------------------------
 NOCOLOR='\033[0m'
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 BLUE='\033[1;34m'
 
-ERROR () {
-  echo -e "${RED}ERROR${NOCOLOR}"
-  exit 1
+# -------------------------------
+# Funciones de manejo de errores y éxito
+# -------------------------------
+ERROR() {
+    echo -e "${RED}ERROR${NOCOLOR}"
+    cleanup
+    exit 1
 }
 
-DONE () {
-  echo -e "${GREEN}DONE${NOCOLOR}"
-  sleep 1
+DONE() {
+    echo -e "${GREEN}DONE${NOCOLOR}\n"
+    sleep 1
 }
 
+# -------------------------------
+# Función de cleanup de locks
+# -------------------------------
+cleanup() {
+    echo -e "${BLUE}>> Limpiando locks si existen${NOCOLOR}"
+    sudo rm -f /var/lib/pacman/db.lck
+}
+
+# Captura SIGTERM y SIGINT para cleanup
+trap cleanup SIGTERM SIGINT
+
+# -------------------------------
+# Comprobación de red
+# -------------------------------
 nm-online >/dev/null 2>&1
 
-echo -e "${BLUE}>>Actualizando paquetes${NOCOLOR}"
-sleep 2
-yay --noconfirm -Sy archlinux-keyring || ERROR
+# -------------------------------
+# Bloque de actualización de paquetes críticos
+# -------------------------------
+echo -e "${BLUE}>> Actualizando paquetes críticos${NOCOLOR}"
+sudo pacman --noconfirm -Sy --needed archlinux-keyring
+sudo systemd-inhibit --what=shutdown --who="CambonOS Upgrade" --why="Actualizando kernel" \
+	sudo pacman --noconfirm -S --needed linux linux-headers linux-firmware || ERROR
+DONE
+
+# -------------------------------
+# Actualización de GRUB
+# -------------------------------
+echo -e "${BLUE}>> Actualizando configuracion de GRUB${NOCOLOR}"
+sudo systemd-inhibit --what=shutdown --who="CambonOS Upgrade" --why="Actualizando configuracion de grub" \
+	sudo grub-mkconfig -o /boot/grub/grub.cfg || ERROR
+DONE
+
+# -------------------------------
+# Actualización del resto de paquetes
+# -------------------------------
+echo -e "${BLUE}>> Actualizando resto de paquetes${NOCOLOR}"
 yay --noconfirm -Syyu || ERROR
 DONE
 
-echo -e "${BLUE}\n>>Eliminando paquetes huerfanos${NOCOLOR}"
-sleep 2
-yay --noconfirm -Rns $(yay -Qqdt)
+# -------------------------------
+# Eliminación de paquetes huérfanos
+# -------------------------------
+echo -e "${BLUE}>> Eliminando paquetes huérfanos${NOCOLOR}"
+yay -Qqdt | xargs -r yay --noconfirm -Rns || true
 DONE
-
-echo -e "${BLUE}\n>>Actualizando GRUB${NOCOLOR}"
-sleep 2
-sudo grub-mkconfig -o /boot/grub/grub.cfg || ERROR
-DONE
-

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -156,7 +156,7 @@ cp /mnt/etc/cambonos-release/* /mnt/etc/
 echo "90" >/tmp/PRG
 
 # Configuracion del firewall
-echo -e "*filter\n:INPUT DROP [0:0]\n:FORWARD DROP [0:0]\n:OUTPUT ACCEPT [0:0]\n-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n-A INPUT -s 127.0.0.1 -j ACCEPT\nCOMMIT" >/mnt/etc/iptables/iptables.rules
+echo -e "*filter\n:INPUT DROP [0:0]\n:FORWARD DROP [0:0]\n:OUTPUT ACCEPT [0:0]\n-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n-A INPUT -s 127.0.0.1 -j ACCEPT\n-A INPUT -p udp --dport 5353 -j ACCEPT\nCOMMIT" >/mnt/etc/iptables/iptables.rules
 echo "systemctl enable iptables.service || exit 1" | ARCH
 echo "91" >/tmp/PRG
 
@@ -164,7 +164,7 @@ echo "91" >/tmp/PRG
 if [[ $SSH = s ]] || [[ $SSH = si ]] || [[ $SSH = S ]] || [[ $SSH = Si ]]
 then
 	echo "pacman --noconfirm -Sy openssh && sed -i s/#X11Forwarding\ no/X11Forwarding\ yes/ /etc/ssh/sshd_config; systemctl enable sshd.service || exit 1" | ARCH
-	echo -e "*filter\n:INPUT DROP [0:0]\n:FORWARD DROP [0:0]\n:OUTPUT ACCEPT [0:0]\n-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n-A INPUT -s 127.0.0.1 -j ACCEPT\n-A INPUT -p tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT\nCOMMIT" >/mnt/etc/iptables/iptables.rules
+	echo -e "*filter\n:INPUT DROP [0:0]\n:FORWARD DROP [0:0]\n:OUTPUT ACCEPT [0:0]\n-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n-A INPUT -s 127.0.0.1 -j ACCEPT\n-A INPUT -p tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT\n-A INPUT -p udp --dport 5353 -j ACCEPT\nCOMMIT" >/mnt/etc/iptables/iptables.rules
 fi
 
 # Configuracion hora

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -61,8 +61,8 @@ echo "35" >/tmp/PRG
 echo "37" >/tmp/PRG
 
 # Instalacion paquetes basicos
-echo "pacman --noconfirm -Sy lsb-release tree htop xclip micro vim man man-db man-pages man-pages-es bash-completion networkmanager ntp systemd-resolvconf $CPU git wget base-devel sudo ntfs-3g dosfstools exfat-utils cpupower rsync plymouth || exit 1" | ARCH || STOP
-echo 'systemctl enable cpupower.service || exit 1' | ARCH
+echo "pacman --noconfirm -Sy lsb-release tree htop xclip micro vim man man-db man-pages man-pages-es bash-completion networkmanager ntp systemd-resolvconf $CPU git wget base-devel sudo ntfs-3g dosfstools exfat-utils cpupower rsync plymouth accountsservice || exit 1" | ARCH || STOP
+echo 'systemctl enable cpupower.service && systemctl enable accounts-daemon.service || exit 1' | ARCH
 echo "45" >/tmp/PRG
 
 # Habilitar repositorios multilib

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -63,7 +63,6 @@ echo "37" >/tmp/PRG
 # Instalacion paquetes basicos
 echo "pacman --noconfirm -Sy lsb-release tree htop xclip micro vim man man-db man-pages man-pages-es bash-completion networkmanager ntp systemd-resolvconf $CPU git wget base-devel sudo ntfs-3g dosfstools exfat-utils cpupower rsync plymouth || exit 1" | ARCH || STOP
 echo 'systemctl enable cpupower.service || exit 1' | ARCH
-echo 'systemctl enable systemd-homed.service || exit 1' | ARCH
 echo "45" >/tmp/PRG
 
 # Habilitar repositorios multilib
@@ -116,7 +115,8 @@ sed -i /interface/d /mnt/etc/NetworkManager/system-connections/*
 echo "$NOMBRE" >/mnt/etc/hostname
 echo -e "127.0.0.1	localhost\n::1		localhost\n127.0.1.1	$NOMBRE" >/mnt/etc/hosts
 sed -i 's/^#MulticastDNS=yes/MulticastDNS=no/' /mnt/etc/systemd/resolved.conf
-echo 'systemctl enable NetworkManager.service && systemctl enable ntpd.service && systemctl enable systemd-resolved.service || exit 1' | ARCH
+sed -i 's/^use-ipv6=yes/use-ipv6=no/' /mnt/etc/avahi/avahi-daemon.conf
+echo 'systemctl enable NetworkManager.service && systemctl enable ntpd.service && systemctl enable systemd-resolved.service && systemctl enable avahi-daemon.service && systemctl enable systemd-homed.service || exit 1' | ARCH
 echo "60" >/tmp/PRG
 
 # Instalacion de yay

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -115,6 +115,7 @@ cp /etc/NetworkManager/system-connections/* /mnt/etc/NetworkManager/system-conne
 sed -i /interface/d /mnt/etc/NetworkManager/system-connections/*
 echo "$NOMBRE" >/mnt/etc/hostname
 echo -e "127.0.0.1	localhost\n::1		localhost\n127.0.1.1	$NOMBRE" >/mnt/etc/hosts
+sed -i 's/^#MulticastDNS=yes/MulticastDNS=no/' /mnt/etc/systemd/resolved.conf
 echo 'systemctl enable NetworkManager.service && systemctl enable ntpd.service && systemctl enable systemd-resolved.service || exit 1' | ARCH
 echo "60" >/tmp/PRG
 

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -63,6 +63,7 @@ echo "37" >/tmp/PRG
 # Instalacion paquetes basicos
 echo "pacman --noconfirm -Sy lsb-release tree htop xclip micro vim man man-db man-pages man-pages-es bash-completion networkmanager ntp systemd-resolvconf $CPU git wget base-devel sudo ntfs-3g dosfstools exfat-utils cpupower rsync plymouth || exit 1" | ARCH || STOP
 echo 'systemctl enable cpupower.service || exit 1' | ARCH
+echo 'systemctl enable systemd-homed.service || exit 1' | ARCH
 echo "45" >/tmp/PRG
 
 # Habilitar repositorios multilib

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -72,12 +72,18 @@ echo "52" >/tmp/PRG
 
 # Instalacion drivers graficos
 if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
-    # Detectar GPU / entorno gráfico
-    GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel|VMware|VirtualBox" | head -n1 | tr '[:upper:]' '[:lower:]')
-    # Detectar GPU híbrida (Intel + Nvidia → Optimus)
-    if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
-        GPU="nvidia-hybrid"
-    fi
+	# Detectar entornovirtual
+	virt_type=$(systemd-detect-virt)
+	if [[ "$virt_type" != "none" ]]; then
+    	GPU="$virt_type"
+	else
+	    # Detectar GPU
+    	GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
+    	# Detectar GPU híbrida (Intel + Nvidia → Optimus)
+    	if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
+        	GPU="nvidia-hybrid"
+    	fi
+	fi
     case $GPU in
         amd)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
@@ -91,7 +97,7 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
         vmware)
             echo "pacman --noconfirm -Sy open-vm-tools mesa lib32-mesa && systemctl enable vmtoolsd.service vmware-vmblock-fuse.service || exit 1" | ARCH
             ;;
-        virtualbox)
+        oracle)
             echo "pacman --noconfirm -Sy virtualbox-guest-utils mesa lib32-mesa && systemctl enable vboxservice.service || exit 1" | ARCH
             ;;
         *)
@@ -179,7 +185,7 @@ echo "92" >/tmp/PRG
 
 # Creacion usuario
 echo "useradd -m -c $ADMINNAME -s /bin/zsh -g users -G wheel,rfkill,sys,lp $ADMINUSER && (echo -e '$ADMINPASS\n$ADMINPASS' | passwd $ADMINUSER)" | ARCH
-if [[ $GPU = virtualbox ]]
+if [[ $GPU = oracle ]]
 then 
 	echo "usermod -aG vboxsf $ADMINUSER" | ARCH
 fi

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -62,7 +62,7 @@ echo "37" >/tmp/PRG
 
 # Instalacion paquetes basicos
 echo "pacman --noconfirm -Sy lsb-release tree htop xclip micro vim man man-db man-pages man-pages-es bash-completion networkmanager ntp systemd-resolvconf $CPU git wget base-devel sudo ntfs-3g dosfstools exfat-utils cpupower rsync plymouth accountsservice || exit 1" | ARCH || STOP
-echo 'systemctl enable cpupower.service && systemctl enable accounts-daemon.service || exit 1' | ARCH
+echo 'systemctl enable cpupower.service ; systemctl enable accounts-daemon.service || exit 1' | ARCH
 echo "45" >/tmp/PRG
 
 # Habilitar repositorios multilib

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -24,6 +24,7 @@ SSH=$5
 UPGRADE=$6
 ESCRITORIO=$7
 DISCO=$8
+echo "1" >/tmp/PRG
 
 # Habilitar NTP
 timedatectl set-ntp true
@@ -31,15 +32,15 @@ echo "2" >/tmp/PRG
 
 # Generar lista de mirrors
 reflector -l 10 -f 5 --save /etc/pacman.d/mirrorlist
-echo "10" >/tmp/PRG
+echo "5" >/tmp/PRG
 
 # Actualizacion de las claves de Arch Linux
 pacman --noconfirm -Sy archlinux-keyring
-echo "15" >/tmp/PRG
+echo "10" >/tmp/PRG
 
 # Creacion de la raiz del sistema
 pacstrap /mnt linux linux-headers linux-firmware base || STOP
-echo "30" >/tmp/PRG
+echo "25" >/tmp/PRG
 
 # Generar fichero fstab del sistema
 dd if=/dev/zero of=/mnt/swapfile bs=1M count=4k status=progress
@@ -47,7 +48,7 @@ chmod 0600 /mnt/swapfile
 mkswap -U clear /mnt/swapfile
 swapon /mnt/swapfile
 genfstab -U /mnt >> /mnt/etc/fstab || STOP
-echo "33" >/tmp/PRG
+echo "30" >/tmp/PRG
 
 # Modificar configuraciones de root
 echo "usermod -s /bin/zsh root" | ARCH # Cambio shell
@@ -58,16 +59,16 @@ echo "35" >/tmp/PRG
 
 # Definicion de los paquetes microcode CPU
 (grep 'Intel' /proc/cpuinfo >/dev/null && CPU='intel-ucode') || (grep 'AMD' /proc/cpuinfo >/dev/null && CPU='amd-ucode') || CPU='amd-ucode intel-ucode'
-echo "37" >/tmp/PRG
+echo "40" >/tmp/PRG
 
 # Instalacion paquetes basicos
 echo "pacman --noconfirm -Sy lsb-release tree htop xclip micro vim man man-db man-pages man-pages-es bash-completion networkmanager ntp systemd-resolvconf $CPU git wget base-devel sudo ntfs-3g dosfstools exfat-utils cpupower rsync plymouth accountsservice || exit 1" | ARCH || STOP
 echo 'systemctl enable cpupower.service ; systemctl enable accounts-daemon.service || exit 1' | ARCH
-echo "45" >/tmp/PRG
+echo "50" >/tmp/PRG
 
 # Habilitar repositorios multilib
 echo -e "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >>/mnt/etc/pacman.conf
-echo "47" >/tmp/PRG
+echo "52" >/tmp/PRG
 
 # Instalacion drivers graficos
 if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
@@ -101,7 +102,7 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
             ;;
     esac
 fi
-echo "50" >/tmp/PRG
+echo "60" >/tmp/PRG
 
 # Instalacion GRUB
 ls /sys/firmware/efi/efivars >/dev/null 2>&1 && GRUB='uefi' || GRUB='bios'
@@ -113,7 +114,7 @@ case $GRUB in
 		echo "pacman --noconfirm -Sy grub os-prober grub-theme-vimix && grub-install --target=i386-pc /dev/$DISCO || exit 1" | ARCH || STOP
 		;;
 esac
-echo "55" >/tmp/PRG
+echo "65" >/tmp/PRG
 
 # Configuraciones de Red
 cp /etc/NetworkManager/system-connections/* /mnt/etc/NetworkManager/system-connections
@@ -123,14 +124,14 @@ echo -e "127.0.0.1	localhost\n::1		localhost\n127.0.1.1	$NOMBRE" >/mnt/etc/hosts
 sed -i 's/^#MulticastDNS=yes/MulticastDNS=no/' /mnt/etc/systemd/resolved.conf
 sed -i 's/^use-ipv6=yes/use-ipv6=no/' /mnt/etc/avahi/avahi-daemon.conf
 echo 'systemctl enable NetworkManager.service ; systemctl enable ntpd.service ; systemctl enable systemd-resolved.service ; systemctl enable avahi-daemon.service ; systemctl enable systemd-homed.service || exit 1' | ARCH
-echo "60" >/tmp/PRG
+echo "66" >/tmp/PRG
 
 # Instalacion de yay
 echo "groupadd -g 777 updates" | ARCH
 echo "useradd -m -d /home/.updates -g updates -u 777 updates && passwd --lock updates || exit 1" | ARCH
 echo -e "\n%updates ALL=(ALL) NOPASSWD: ALL" >> /mnt/etc/sudoers
 echo "echo 'cd /tmp && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg --noconfirm -si || exit 1' | su updates || exit 1" | ARCH
-echo "65" >/tmp/PRG
+echo "68" >/tmp/PRG
 
 # Instalacion de utilidades adicionales
 echo "echo 'yay --noconfirm -Sy neofetch zsh zsh-completions zsh-autosuggestions zsh-syntax-highlighting zsh-theme-powerlevel10k-bin-git ttf-meslo-nerd-font-powerlevel10k xdg-user-dirs libpwquality || exit 1' | su updates || exit 1" | ARCH

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -116,7 +116,7 @@ echo "$NOMBRE" >/mnt/etc/hostname
 echo -e "127.0.0.1	localhost\n::1		localhost\n127.0.1.1	$NOMBRE" >/mnt/etc/hosts
 sed -i 's/^#MulticastDNS=yes/MulticastDNS=no/' /mnt/etc/systemd/resolved.conf
 sed -i 's/^use-ipv6=yes/use-ipv6=no/' /mnt/etc/avahi/avahi-daemon.conf
-echo 'systemctl enable NetworkManager.service && systemctl enable ntpd.service && systemctl enable systemd-resolved.service && systemctl enable avahi-daemon.service && systemctl enable systemd-homed.service || exit 1' | ARCH
+echo 'systemctl enable NetworkManager.service ; systemctl enable ntpd.service ; systemctl enable systemd-resolved.service ; systemctl enable avahi-daemon.service ; systemctl enable systemd-homed.service || exit 1' | ARCH
 echo "60" >/tmp/PRG
 
 # Instalacion de yay

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -173,7 +173,7 @@ echo "ln -sf /usr/share/zoneinfo/Europe/Madrid /etc/localtime && hwclock --systo
 echo "92" >/tmp/PRG
 
 # Creacion usuario
-echo "useradd -m -c $ADMINNAME -s /bin/zsh -g users -G wheel,rfkill,sys $ADMINUSER && (echo -e '$ADMINPASS\n$ADMINPASS' | passwd $ADMINUSER)" | ARCH
+echo "useradd -m -c $ADMINNAME -s /bin/zsh -g users -G wheel,rfkill,sys,lp $ADMINUSER && (echo -e '$ADMINPASS\n$ADMINPASS' | passwd $ADMINUSER)" | ARCH
 if [[ $GPU = vmware ]]
 then 
 	echo "usermod -aG vboxsf $ADMINUSER" | ARCH

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -70,31 +70,58 @@ echo -e "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >>/mnt/etc/pacman.con
 echo "47" >/tmp/PRG
 
 # Instalacion drivers graficos
-if [[ $DG = s ]] || [[ $DG = S ]] || [[ $DG = si ]] || [[ $DG = Si ]]
-then
-	GPU='DESCONOCIDA'
-	(lspci | grep VGA) | grep -o 'VMware' >/dev/null && GPU='vmware'
-	(lspci | grep VGA) | grep -o 'Intel' >/dev/null && GPU='intel'
-	(lspci | grep VGA) | grep -o 'AMD' >/dev/null && GPU='amd'
-	(lspci | grep VGA) | grep -o 'NVIDIA' >/dev/null && GPU='nvidia'
-	(lspci | grep "3D controller") | grep -o 'VMware' >/dev/null && GPU='vmware'
-	(lspci | grep "3D controller") | grep -o 'Intel' >/dev/null && GPU='intel'
-	(lspci | grep "3D controller") | grep -o 'AMD' >/dev/null && GPU='amd'
-	(lspci | grep "3D controller") | grep -o 'NVIDIA' >/dev/null && GPU='onvidia'
-	case $GPU in
-		amd)
-			echo "pacman --noconfirm -Sy xf86-video-vesa xf86-video-amdgpu lib32-mesa mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH ;;
-		nvidia)
-			echo "pacman --noconfirm -Sy xf86-video-vesa nvidia lib32-nvidia-utils nvidia-utils nvidia-settings nvidia-dkms vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH ;;
-  		onvidia)
-			echo "pacman --noconfirm -Sy xf86-video-vesa nvidia lib32-nvidia-utils nvidia-utils nvidia-settings nvidia-dkms vulkan-icd-loader lib32-vulkan-icd-loader optimus-manager optimus-manager-qt || exit 1" | ARCH ;;
-  		intel)
-			echo "pacman --noconfirm -Sy xf86-video-vesa xf86-video-intel lib32-mesa mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH ;;
-		vmware)
-			echo "pacman --noconfirm -Sy virtualbox-guest-utils xf86-video-vesa xf86-video-vmware lib32-mesa mesa || exit 1" | ARCH ;;
-		*)
-			echo "pacman --noconfirm -Sy xf86-video-vesa lib32-mesa mesa vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH ;;
-	esac
+if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
+    # Detectar GPU / entorno gráfico
+    GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel|VMware|VirtualBox|InnoTek" | head -n1 | tr '[:upper:]' '[:lower:]')
+    # Detectar GPU híbrida (Intel + Nvidia → Optimus)
+    if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
+        GPU="nvidia-hybrid"
+    fi
+    # Normalizar nombres
+    [[ $GPU == "innotek" ]] && GPU="virtualbox"
+    case $GPU in
+        amd)
+            pacman --noconfirm -Sy \
+                mesa lib32-mesa \
+                vulkan-radeon lib32-vulkan-radeon \
+                vulkan-icd-loader lib32-vulkan-icd-loader
+            ;;
+        nvidia)
+            pacman --noconfirm -Sy \
+                nvidia nvidia-utils lib32-nvidia-utils \
+                nvidia-settings \
+                vulkan-icd-loader lib32-vulkan-icd-loader
+            ;;
+        nvidia-hybrid)
+            pacman --noconfirm -Sy \
+                nvidia nvidia-utils lib32-nvidia-utils \
+                nvidia-settings \
+                optimus-manager optimus-manager-qt \
+                vulkan-icd-loader lib32-vulkan-icd-loader
+            ;;
+        intel)
+            pacman --noconfirm -Sy \
+                mesa lib32-mesa \
+                vulkan-intel lib32-vulkan-intel \
+                vulkan-icd-loader lib32-vulkan-icd-loader
+            ;;
+        vmware)
+            pacman --noconfirm -Sy \
+                open-vm-tools xf86-video-vmware \
+                mesa lib32-mesa
+            systemctl enable --now vmtoolsd.service || true
+            ;;
+        virtualbox)
+            pacman --noconfirm -Sy \
+                virtualbox-guest-utils mesa lib32-mesa
+            systemctl enable --now vboxservice.service || true
+            ;;
+        *)
+            pacman --noconfirm -Sy \
+                mesa lib32-mesa \
+                vulkan-icd-loader lib32-vulkan-icd-loader
+            ;;
+    esac
 fi
 
 # Instalacion GRUB

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -81,45 +81,52 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
     [[ $GPU == "innotek" ]] && GPU="virtualbox"
     case $GPU in
         amd)
-            pacman --noconfirm -Sy \
+            echo "pacman --noconfirm -Sy \
                 mesa lib32-mesa \
                 vulkan-radeon lib32-vulkan-radeon \
-                vulkan-icd-loader lib32-vulkan-icd-loader
+                vulkan-icd-loader lib32-vulkan-icd-loader \
+				|| exit 1" | ARCH
             ;;
         nvidia)
-            pacman --noconfirm -Sy \
+            echo "pacman --noconfirm -Sy \
                 nvidia nvidia-utils lib32-nvidia-utils \
                 nvidia-settings \
-                vulkan-icd-loader lib32-vulkan-icd-loader
+                vulkan-icd-loader lib32-vulkan-icd-loader \
+				|| exit 1" | ARCH
             ;;
         nvidia-hybrid)
-            pacman --noconfirm -Sy \
+            echo "pacman --noconfirm -Sy \
                 nvidia nvidia-utils lib32-nvidia-utils \
                 nvidia-settings \
                 optimus-manager optimus-manager-qt \
-                vulkan-icd-loader lib32-vulkan-icd-loader
+                vulkan-icd-loader lib32-vulkan-icd-loader \
+				|| exit 1" | ARCH
             ;;
         intel)
-            pacman --noconfirm -Sy \
+            echo "pacman --noconfirm -Sy \
                 mesa lib32-mesa \
                 vulkan-intel lib32-vulkan-intel \
-                vulkan-icd-loader lib32-vulkan-icd-loader
+                vulkan-icd-loader lib32-vulkan-icd-loader \
+				|| exit 1" | ARCH
             ;;
         vmware)
-            pacman --noconfirm -Sy \
+            echo "pacman --noconfirm -Sy \
                 open-vm-tools xf86-video-vmware \
-                mesa lib32-mesa
-            systemctl enable --now vmtoolsd.service || true
+                mesa lib32-mesa && \
+				systemctl enable --now vmtoolsd.service \
+				|| exit 1" | ARCH
             ;;
         virtualbox)
-            pacman --noconfirm -Sy \
-                virtualbox-guest-utils mesa lib32-mesa
-            systemctl enable --now vboxservice.service || true
+            echo "pacman --noconfirm -Sy \
+                virtualbox-guest-utils mesa lib32-mesa && \
+				systemctl enable --now vboxservice.service \
+				|| exit 1" | ARCH
             ;;
         *)
-            pacman --noconfirm -Sy \
+            echo "pacman --noconfirm -Sy \
                 mesa lib32-mesa \
-                vulkan-icd-loader lib32-vulkan-icd-loader
+                vulkan-icd-loader lib32-vulkan-icd-loader \
+				|| exit 1" | ARCH
             ;;
     esac
 fi

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -72,61 +72,32 @@ echo "47" >/tmp/PRG
 # Instalacion drivers graficos
 if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
     # Detectar GPU / entorno gráfico
-    GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel|VMware|VirtualBox|InnoTek" | head -n1 | tr '[:upper:]' '[:lower:]')
+    GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel|VMware|VirtualBox" | head -n1 | tr '[:upper:]' '[:lower:]')
     # Detectar GPU híbrida (Intel + Nvidia → Optimus)
     if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
         GPU="nvidia-hybrid"
     fi
-    # Normalizar nombres
-    [[ $GPU == "innotek" ]] && GPU="virtualbox"
     case $GPU in
         amd)
-            echo "pacman --noconfirm -Sy \
-                mesa lib32-mesa \
-                vulkan-radeon lib32-vulkan-radeon \
-                vulkan-icd-loader lib32-vulkan-icd-loader \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         nvidia)
-            echo "pacman --noconfirm -Sy \
-                nvidia nvidia-utils lib32-nvidia-utils \
-                nvidia-settings \
-                vulkan-icd-loader lib32-vulkan-icd-loader \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         nvidia-hybrid)
-            echo "pacman --noconfirm -Sy \
-                nvidia nvidia-utils lib32-nvidia-utils \
-                nvidia-settings \
-                optimus-manager optimus-manager-qt \
-                vulkan-icd-loader lib32-vulkan-icd-loader \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader optimus-manager optimus-manager-qt || exit 1" | ARCH
             ;;
         intel)
-            echo "pacman --noconfirm -Sy \
-                mesa lib32-mesa \
-                vulkan-intel lib32-vulkan-intel \
-                vulkan-icd-loader lib32-vulkan-icd-loader \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         vmware)
-            echo "pacman --noconfirm -Sy \
-                open-vm-tools xf86-video-vmware \
-                mesa lib32-mesa && \
-				systemctl enable --now vmtoolsd.service \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy open-vm-tools xf86-video-vmware mesa lib32-mesa && systemctl enable vmtoolsd.service || exit 1" | ARCH
             ;;
         virtualbox)
-            echo "pacman --noconfirm -Sy \
-                virtualbox-guest-utils mesa lib32-mesa && \
-				systemctl enable --now vboxservice.service \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy virtualbox-guest-utils mesa lib32-mesa && systemctl enable vboxservice.service || exit 1" | ARCH
             ;;
         *)
-            echo "pacman --noconfirm -Sy \
-                mesa lib32-mesa \
-                vulkan-icd-loader lib32-vulkan-icd-loader \
-				|| exit 1" | ARCH
+            echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
     esac
 fi

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -19,11 +19,9 @@ NOMBRE=$1
 ADMINNAME=$2
 ADMINUSER=$(echo $ADMINNAME | awk '{print tolower($0)}')
 ADMINPASS=$3
-DG=$4
+ESCRITORIO=$4
 SSH=$5
-UPGRADE=$6
-ESCRITORIO=$7
-DISCO=$8
+DISCO=$6
 echo "1" >/tmp/PRG
 
 # Habilitar NTP
@@ -71,28 +69,26 @@ echo -e "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >>/mnt/etc/pacman.con
 echo "52" >/tmp/PRG
 
 # Instalacion drivers graficos
-if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
-	# Detectar GPU
-	GPU=$(lspci | grep -E "VGA|3D" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
-	# Detectar GPU híbrida (Intel + Nvidia → Optimus)
-	if lspci | grep -E "VGA|3D" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
-		GPU="nvidia-hybrid"
-	fi
-    case $GPU in
-        amd)
-            echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
-            ;;
-        nvidia|nvidia-hybrid)
-            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
-            ;;
-        intel)
-            echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
-            ;;
-        *)
-            echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
-            ;;
-    esac
+# Detectar GPU
+GPU=$(lspci | grep -E "VGA|3D" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
+# Detectar GPU híbrida (Intel + Nvidia → Optimus)
+if lspci | grep -E "VGA|3D" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
+	GPU="nvidia-hybrid"
 fi
+case $GPU in
+	amd)
+		echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
+		;;
+	nvidia|nvidia-hybrid)
+		echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
+		;;
+	intel)
+		echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
+		;;
+	*)
+		echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
+		;;
+esac
 echo "60" >/tmp/PRG
 
 # Instalacion GRUB
@@ -134,18 +130,16 @@ echo "70" >/tmp/PRG
 
 # Instalacion XFCE
 (sleep 2; while [[ $(cat /mnt/tmp/PRG) -ne 85 ]]; do cp /mnt/tmp/PRG /tmp/PRG; sleep 1; done) &
-echo $ESCRITORIO | grep "1" >/dev/nul && INSTALL=true || INSTALL=false
-if [[ $INSTALL = true ]]
-then	
-	echo 'echo "cd /tmp; git clone https://github.com/Cambon18/xfce && cd xfce && bash archie.sh" | su updates' | ARCH
-fi
-
-# Instalacion Qtile
-echo $ESCRITORIO | grep "2" >/dev/nul && INSTALL=true || INSTALL=false
-if [[ $INSTALL = true ]]
-then
-	echo 'echo "cd /tmp; git clone https://github.com/Cambon18/qtile && cd qtile && bash archie.sh" | su updates' | ARCH
-fi
+case "$ESCRITORIO" in
+    1)
+        # Instalación XFCE
+        echo 'echo "cd /tmp; git clone https://github.com/Cambon18/xfce && cd xfce && bash archie.sh" | su updates' | ARCH
+        ;;
+    2)
+        # Instalación Qtile
+        echo 'echo "cd /tmp; git clone https://github.com/Cambon18/qtile && cd qtile && bash archie.sh" | su updates' | ARCH
+        ;;
+esac
 echo "85" >/tmp/PRG
 
 # Configuraciones CambonOS
@@ -173,19 +167,12 @@ echo "92" >/tmp/PRG
 
 # Creacion usuario
 echo "useradd -m -c $ADMINNAME -s /bin/zsh -g users -G wheel,rfkill,sys,lp $ADMINUSER && (echo -e '$ADMINPASS\n$ADMINPASS' | passwd $ADMINUSER)" | ARCH
-if [[ $GPU = oracle ]]
-then 
-	echo "usermod -aG vboxsf $ADMINUSER" | ARCH
-fi
 echo "94" >/tmp/PRG
 
 # Configuracion cambonos-upgrade
 echo "chown updates:wheel /usr/bin/cambonos-upgrade; chmod 750 /usr/bin/cambonos-upgrade" | ARCH
 echo "chsh -s /usr/bin/nologin updates" | ARCH
-if [[ $UPGRADE = s ]] || [[ $UPGRADE = si ]] || [[ $UPGRADE = S ]] || [[ $UPGRADE = Si ]]
-then
-	echo "systemctl enable cambonos-upgrade.timer || exit 1" | ARCH
-fi
+echo "systemctl enable cambonos-upgrade.timer || exit 1" | ARCH
 echo "96" >/tmp/PRG
 
 # Generacion locales

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -72,22 +72,18 @@ echo "52" >/tmp/PRG
 
 # Instalacion drivers graficos
 if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
-	# Detectar GPU NVIDIA
-	GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel" | tr '[:upper:]' '[:lower:]' | grep -m1 'nvidia')
-	# Si no se encuentra NVIDIA, toma la primera disponible
-	GPU=${GPU:-$(lspci | grep -E "VGA|3D controller" | grep -oE "AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')}
 	# Detectar GPU
-	#GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
+	GPU=$(lspci | grep -E "VGA|3D" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
 	# Detectar GPU híbrida (Intel + Nvidia → Optimus)
-	#if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
-	#	GPU="nvidia-hybrid"
-	#fi
+	if lspci | grep -E "VGA|3D" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
+		GPU="nvidia-hybrid"
+	fi
     case $GPU in
         amd)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         nvidia|nvidia-hybrid)
-            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader && busid=$(lspci | grep NVIDIA | grep -E "VGA|3D Controller" | cut -d " " -f 1) && echo -e "Section \"Device\"\n\tIdentifier \"NVIDIA GPU\"\n\tDriver \"nvidia\"\n\tBusID \"PCI:$busid\"\n\tOption \"PrimaryGPU\" \"yes\"\nEndSection" >/etc/X11/xorg.conf.d/10-nvidia.conf || exit 1" | ARCH
+            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         intel)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -134,12 +134,14 @@ case "$ESCRITORIO" in
     1)
         # Instalación XFCE
 		cp -r /root/xfce /mnt/xfce
-        echo 'echo "cd /xfce && bash archie.sh; sudo rm -rf /xfce" | su updates' | ARCH
+        echo 'chown -R updates:updates /xfce; echo "cd /xfce && bash archie.sh" | su updates' | ARCH
+		rm -rf /mnt/xfce
         ;;
     2)
         # Instalación Qtile
 		cp -r /root/qtile /mnt/qtile
-        echo 'echo "cd /qtile && bash archie.sh; sudo rm -rf /qtile" | su updates' | ARCH
+        echo 'chown -R updates:updates /qtile; echo "cd /qtile && bash archie.sh" | su updates' | ARCH
+		rm -rf /mnt/qtile
         ;;
 esac
 echo "85" >/tmp/PRG

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -95,7 +95,7 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         vmware)
-            echo "pacman --noconfirm -Sy open-vm-tools mesa lib32-mesa && systemctl enable vmtoolsd.service vmware-vmblock-fuse.service || exit 1" | ARCH
+            echo "pacman --noconfirm -Sy open-vm-tools mesa lib32-mesa xf86-input-vmmouse && systemctl enable vmtoolsd.service vmware-vmblock-fuse.service || exit 1" | ARCH
             ;;
         oracle)
             echo "pacman --noconfirm -Sy virtualbox-guest-utils mesa lib32-mesa && systemctl enable vboxservice.service || exit 1" | ARCH

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -89,7 +89,7 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         vmware)
-            echo "pacman --noconfirm -Sy open-vm-tools xf86-video-vmware mesa lib32-mesa && systemctl enable vmtoolsd.service || exit 1" | ARCH
+            echo "pacman --noconfirm -Sy open-vm-tools mesa lib32-mesa && systemctl enable vmtoolsd.service vmware-vmblock-fuse.service || exit 1" | ARCH
             ;;
         virtualbox)
             echo "pacman --noconfirm -Sy virtualbox-guest-utils mesa lib32-mesa && systemctl enable vboxservice.service || exit 1" | ARCH

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -133,11 +133,13 @@ echo "70" >/tmp/PRG
 case "$ESCRITORIO" in
     1)
         # Instalación XFCE
-        echo 'echo "cd /tmp; git clone https://github.com/Cambon18/xfce && cd xfce && bash archie.sh" | su updates' | ARCH
+		cp -r /root/xfce /mnt/xfce
+        echo 'echo "cd /xfce && bash archie.sh; sudo rm -rf /xfce" | su updates' | ARCH
         ;;
     2)
         # Instalación Qtile
-        echo 'echo "cd /tmp; git clone https://github.com/Cambon18/qtile && cd qtile && bash archie.sh" | su updates' | ARCH
+		cp -r /root/qtile /mnt/qtile
+        echo 'echo "cd /qtile && bash archie.sh; sudo rm -rf /qtile" | su updates' | ARCH
         ;;
 esac
 echo "85" >/tmp/PRG

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -38,7 +38,7 @@ pacman --noconfirm -Sy archlinux-keyring
 echo "15" >/tmp/PRG
 
 # Creacion de la raiz del sistema
-pacstrap /mnt linux-zen linux-zen-headers linux-firmware base || STOP
+pacstrap /mnt linux linux-headers linux-firmware base || STOP
 echo "30" >/tmp/PRG
 
 # Generar fichero fstab del sistema

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -166,6 +166,7 @@ echo "echo 'yay --noconfirm -Sy neofetch zsh zsh-completions zsh-autosuggestions
 echo "70" >/tmp/PRG
 
 # Instalacion XFCE
+(sleep 2; while [[ $(cat /mnt/tmp/PRG) -ne 85 ]]; do cp /mnt/tmp/PRG /tmp/PRG; sleep 1; done) &
 echo $ESCRITORIO | grep "1" >/dev/nul && INSTALL=true || INSTALL=false
 if [[ $INSTALL = true ]]
 then	
@@ -205,7 +206,7 @@ echo "92" >/tmp/PRG
 
 # Creacion usuario
 echo "useradd -m -c $ADMINNAME -s /bin/zsh -g users -G wheel,rfkill,sys,lp $ADMINUSER && (echo -e '$ADMINPASS\n$ADMINPASS' | passwd $ADMINUSER)" | ARCH
-if [[ $GPU = vmware ]]
+if [[ $GPU = virtualbox ]]
 then 
 	echo "usermod -aG vboxsf $ADMINUSER" | ARCH
 fi

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -72,33 +72,25 @@ echo "52" >/tmp/PRG
 
 # Instalacion drivers graficos
 if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
-	# Detectar entornovirtual
-	virt_type=$(systemd-detect-virt)
-	if [[ "$virt_type" != "none" ]]; then
-    	GPU="$virt_type"
-	else
-	    # Detectar GPU
-    	GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
-    	# Detectar GPU híbrida (Intel + Nvidia → Optimus)
-    	if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
-        	GPU="nvidia-hybrid"
-    	fi
-	fi
+	# Detectar GPU NVIDIA
+	GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel" | tr '[:upper:]' '[:lower:]' | grep -m1 'nvidia')
+	# Si no se encuentra NVIDIA, toma la primera disponible
+	GPU=${GPU:-$(lspci | grep -E "VGA|3D controller" | grep -oE "AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')}
+	# Detectar GPU
+	#GPU=$(lspci | grep -E "VGA|3D controller" | grep -oE "NVIDIA|AMD|Intel" | head -n1 | tr '[:upper:]' '[:lower:]')
+	# Detectar GPU híbrida (Intel + Nvidia → Optimus)
+	#if lspci | grep -E "VGA|3D controller" | grep -q "NVIDIA" && lspci | grep -q "Intel"; then
+	#	GPU="nvidia-hybrid"
+	#fi
     case $GPU in
         amd)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
         nvidia|nvidia-hybrid)
-            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
+            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader && busid=$(lspci | grep NVIDIA | grep -E "VGA|3D Controller" | cut -d " " -f 1) && echo -e "Section \"Device\"\n\tIdentifier \"NVIDIA GPU\"\n\tDriver \"nvidia\"\n\tBusID \"PCI:$busid\"\n\tOption \"PrimaryGPU\" \"yes\"\nEndSection" >/etc/X11/xorg.conf.d/10-nvidia.conf || exit 1" | ARCH
             ;;
         intel)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
-            ;;
-        vmware)
-            echo "pacman --noconfirm -Sy open-vm-tools mesa lib32-mesa xf86-input-vmmouse && systemctl enable vmtoolsd.service vmware-vmblock-fuse.service || exit 1" | ARCH
-            ;;
-        oracle)
-            echo "pacman --noconfirm -Sy virtualbox-guest-utils mesa lib32-mesa && systemctl enable vboxservice.service || exit 1" | ARCH
             ;;
         *)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -82,11 +82,8 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
         amd)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
             ;;
-        nvidia)
+        nvidia|nvidia-hybrid)
             echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
-            ;;
-        nvidia-hybrid)
-            echo "pacman --noconfirm -Sy nvidia nvidia-utils lib32-nvidia-utils nvidia-settings vulkan-icd-loader lib32-vulkan-icd-loader optimus-manager optimus-manager-qt || exit 1" | ARCH
             ;;
         intel)
             echo "pacman --noconfirm -Sy mesa lib32-mesa vulkan-intel lib32-vulkan-intel vulkan-icd-loader lib32-vulkan-icd-loader || exit 1" | ARCH
@@ -135,6 +132,10 @@ echo "68" >/tmp/PRG
 
 # Instalacion de utilidades adicionales
 echo "echo 'yay --noconfirm -Sy neofetch zsh zsh-completions zsh-autosuggestions zsh-syntax-highlighting zsh-theme-powerlevel10k-bin-git ttf-meslo-nerd-font-powerlevel10k xdg-user-dirs libpwquality || exit 1' | su updates || exit 1" | ARCH
+if [[ $GPU = nvidia-hybrid ]]
+then 
+	echo "echo 'yay --noconfirm -Sy optimus-manager optimus-manager-qt || exit 1' | su updates || exit 1" | ARCH
+fi
 echo "70" >/tmp/PRG
 
 # Instalacion XFCE

--- a/cambonos-install.sh
+++ b/cambonos-install.sh
@@ -123,6 +123,7 @@ if [[ $DG =~ ^([sS]|si|Si)$ ]]; then
             ;;
     esac
 fi
+echo "50" >/tmp/PRG
 
 # Instalacion GRUB
 ls /sys/firmware/efi/efivars >/dev/null 2>&1 && GRUB='uefi' || GRUB='bios'
@@ -155,10 +156,6 @@ echo "65" >/tmp/PRG
 
 # Instalacion de utilidades adicionales
 echo "echo 'yay --noconfirm -Sy neofetch zsh zsh-completions zsh-autosuggestions zsh-syntax-highlighting zsh-theme-powerlevel10k-bin-git ttf-meslo-nerd-font-powerlevel10k xdg-user-dirs libpwquality || exit 1' | su updates || exit 1" | ARCH
-if [[ $GPU = vmware ]]
-then
-	echo "echo 'yay --noconfirm -Sy virtualbox-guest-utils || exit 1' | su updates || exit 1" | ARCH && echo "systemctl enable vboxservice.service" | ARCH
-fi
 echo "70" >/tmp/PRG
 
 # Instalacion XFCE

--- a/dialog.sh
+++ b/dialog.sh
@@ -34,7 +34,7 @@ do
 	DISCO=$(cat /tmp/disco)
 	
 	# Ventana de confirmación opciones	
-	dialog --title " CambonOS Installer " --yesno "\nPor favor, confirme que las opciones seleccionadas son correctas:\n\nNombre del equipo: $NOMBRE\nNombre para el administrador: $ADMINNAME\nInstalar los drivers gráficos: $DG\nInstalar servidor SSH: $SSH\nActualización automatica: $UPGRADE\nEntorno de escritorio seleccionado: $ESCRITORIO" 15 80 && break
+	dialog --title " CambonOS Installer " --yesno "\nPor favor, confirme que las opciones seleccionadas son correctas:\n\nNombre del equipo: $NOMBRE\nNombre del usuario: $ADMINNAME\nEntorno de escritorio seleccionado: $ESCRITORIO\nInstalar servidor SSH: $SSH" 15 80 && break
 done
 
 # Ejecucion del script de instalación
@@ -43,4 +43,3 @@ sh installer/cambonos-install.sh $NOMBRE $ADMINNAME $PASS $ESCRITORIO $SSH $DISC
 # Monitorizacion del script de instalación
 echo "0" >/tmp/PRG
 (while [[ $(cat /tmp/PRG) -ne 100 ]]; do sleep 1; cat /tmp/PRG; done) | dialog --title " CambonOS Installer " --gauge "Instalando..." 7 80 0
-

--- a/dialog.sh
+++ b/dialog.sh
@@ -9,8 +9,10 @@ do
 	NOMBRE=$(dialog --stdout --title " CambonOS Installer " --inputbox "\nNombre del equipo:" 10 80)
 	NOMBRE=$(echo $NOMBRE | awk '{print tolower($0)}')
 	
-	# Ventana de entrada de nombre para el nuevo usuario administrador
+	# Ventana de entrada de nombre para el nuevo usuario
 	ADMINNAME=$(dialog --stdout --title " CambonOS Installer " --inputbox "\nNombre para el usuario administrador:" 10 80 "Administrador")
+
+	# Ventana de entrada de contraseña para el nuevo usuario
 	PASS=$(dialog --stdout --title " CambonOS Installer " --passwordbox "\nContraseña del usuario:" 10 80)
 	PASS1=$(dialog --stdout --title " CambonOS Installer " --passwordbox "\nRepetir contraseña:" 10 80)
 	while [ $PASS != $PASS1 ] 
@@ -19,22 +21,15 @@ do
 		PASS=$(dialog --stdout --title " CambonOS Installer " --passwordbox "\nContraseña del usuario:" 10 80)
 		PASS1=$(dialog --stdout --title " CambonOS Installer " --passwordbox "\nRepetir contraseña:" 10 80)
 	done
-
-	# Ventana de selección de instalación de controladores gráficos
-	DG=$(dialog --stdout --title " CambonOS Installer " --yesno "\nDesea instalar los drivers gráficos?" 7 80 && echo "Si" || echo "No")
-	
-	# Ventana de selección de instalación de servidor SSH
-	SSH=$(dialog --stdout --title " CambonOS Installer " --yesno "\nDesea instalar servidor SSH?" 7 80 && echo "Si" || echo "No")
-	
-	# Ventana de selección de actualizacion automatica
-	UPGRADE=$(dialog --stdout --title " CambonOS Installer " --yesno "\nDesea que los paquetes del sistema se actualicen automáticamente?" 7 80 && echo "Si" || echo "No")
 	
 	# Ventana de selección de entorno de escritorio
 	ESCRITORIO=$(dialog --stdout --title " CambonOS Installer " --menu "\nQué entorno de escritorio desea instalar?\n" 15 80 10 \
 	        1 "Cambon18/XFCE (Recomendado)" \
-	        2 "Cambon18/Qtile" \
-	        3 "No instalar interfaz gráfica")
-	
+	        2 "Cambon18/Qtile")
+
+	# Ventana de selección de instalación de servidor SSH
+	SSH=$(dialog --stdout --title " CambonOS Installer " --yesno "\nDesea instalar servidor SSH?" 7 80 && echo "Si" || echo "No")
+
 	# Disco de instalación
 	DISCO=$(cat /tmp/disco)
 	
@@ -43,7 +38,7 @@ do
 done
 
 # Ejecucion del script de instalación
-sh installer/cambonos-install.sh $NOMBRE $ADMINNAME $PASS $DG $SSH $UPGRADE $ESCRITORIO $DISCO >/tmp/install 2>&1 &
+sh installer/cambonos-install.sh $NOMBRE $ADMINNAME $PASS $ESCRITORIO $SSH $DISCO >/tmp/install 2>&1 &
 
 # Monitorizacion del script de instalación
 echo "0" >/tmp/PRG

--- a/parted.sh
+++ b/parted.sh
@@ -41,7 +41,7 @@ Para continuar su intalacion escoga entre:
 					lsblk | grep $DISCOP$N >>$SALIDA 2>&1 && N=$(($N+1)) || LIBRE=1
 				done
 				echo -e "\n>>Particionando disco...\c"
-				(echo -e "n\n\n\n+512M\nn\n\n\n+30G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
+				(echo -e "n\n\n\n+2G\nn\n\n\n+40G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
 				;;
 			esac
 		else 
@@ -52,7 +52,7 @@ Para continuar su intalacion escoga entre:
 			else exit
 			fi
 			echo -e "\n>>Particionando disco...\c"
-			(echo -e "g\nn\n\n\n+512M\nn\n\n\n+30G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
+			(echo -e "g\nn\n\n\n+2G\nn\n\n\n+40G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
 		fi
 		yes | mkfs.vfat -F 32 /dev/$DISCOP$N >>$SALIDA 2>&1 || STOP && N=$(($N+1))
 		yes | mkfs.ext4 /dev/$DISCOP$N >>$SALIDA 2>&1 || STOP && N=$(($N+1))

--- a/parted.sh
+++ b/parted.sh
@@ -41,7 +41,7 @@ Para continuar su intalacion escoga entre:
 					lsblk | grep $DISCOP$N >>$SALIDA 2>&1 && N=$(($N+1)) || LIBRE=1
 				done
 				echo -e "\n>>Particionando disco...\c"
-				(echo -e "n\n\n\n+2G\nn\n\n\n+40G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
+				(echo -e "n\n\n\n+1G\nn\n\n\n+40G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
 				;;
 			esac
 		else 
@@ -52,7 +52,7 @@ Para continuar su intalacion escoga entre:
 			else exit
 			fi
 			echo -e "\n>>Particionando disco...\c"
-			(echo -e "g\nn\n\n\n+2G\nn\n\n\n+40G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
+			(echo -e "g\nn\n\n\n+1G\nn\n\n\n+40G\nn\n\n\n\nw\n" | fdisk -w always /dev/$DISCO >>$SALIDA 2>&1) || STOP
 		fi
 		yes | mkfs.vfat -F 32 /dev/$DISCOP$N >>$SALIDA 2>&1 || STOP && N=$(($N+1))
 		yes | mkfs.ext4 /dev/$DISCOP$N >>$SALIDA 2>&1 || STOP && N=$(($N+1))


### PR DESCRIPTION
# Cambonos 25.11

**Resumen de la versión:**  
Versión centrada en compatibilidad de hardware, estabilidad del sistema, seguridad y mejoras del instalador. Incluye soporte completo para gráficas AMD, Intel, NVIDIA y configuraciones híbridas, optimizaciones de scripts críticos, correcciones de servicios de red y mejoras en la experiencia de instalación.

---

## [25.11]

### Añadido
- `etc/X11/xorg.conf.d/30-touchpad.conf` para configuración de **touchpads** mediante *libinput*.
- Paquete **accounts-daemon** para gestión de cuentas de usuario vía D-Bus.

### Corregido
- Configuración de **Pacman** para deshabilitar el repositorio *community*.
- Correcciones en **avahi-daemon** para detección y anuncio de servicios en red local.

### Seguridad
- Restricción de permisos **sudo** para el usuario `updates`.

### Mejorado
- Optimización de `cambonos-upgrade` y `cambonos-upgrade.service` para prevenir reinicios/apagados durante actualización de **paquetes críticos**.
- Cambios menores en la barra de progreso del instalador.
- Reestructuración del apartado de instalación de drivers gráficos, considerando **AMD, Intel, NVIDIA y NVIDIA Hybrid**.
- Ajustes en preguntas y orden en el instalador para mejorar la experiencia de usuario.